### PR TITLE
Set unique names for all testbench modules

### DIFF
--- a/bench/verilog/GPIA_BIT.v
+++ b/bench/verilog/GPIA_BIT.v
@@ -5,7 +5,7 @@
  * identified by a number on the `scenario_o` bus.
  */
 
-module test();
+module test_bit();
 
 reg clk_o;
 reg rst_o;

--- a/bench/verilog/GPIA_BIT_IN.v
+++ b/bench/verilog/GPIA_BIT_IN.v
@@ -8,7 +8,7 @@
  * read the current state of the external signal attached to it.
  */
 
-module test();
+module test_bit_in();
 
 reg out_o;
 reg inp_o;

--- a/bench/verilog/GPIA_BYTE.v
+++ b/bench/verilog/GPIA_BYTE.v
@@ -16,7 +16,7 @@
  * - Toggle an arbitrary set of bits truth value in a single cycle.
  */
 
-module test();
+module test_byte();
 
 reg clk_o;
 reg rst_o;

--- a/bench/verilog/GPIA_DWORD.v
+++ b/bench/verilog/GPIA_DWORD.v
@@ -19,7 +19,7 @@
  * stb_i inputs.
  */
 
-module test();
+module test_dword();
 
 reg clk_o;
 reg rst_o;


### PR DESCRIPTION
This avoids name conflicts when all testbenches are compiled at
the same time
